### PR TITLE
Improve command line filtering options

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -57,6 +57,7 @@ def load_data(data_paths, filter_conversation=None, filter_sender=None, remove_s
     merged = pd.merge(df, mf, on=['conversationWithName'], how='inner')
     merged = merged[['datetime', 'conversationWithName', 'senderName']]
 
+
     print('Number to render:', len(merged))
     print(merged.head())
     return merged
@@ -64,6 +65,10 @@ def load_data(data_paths, filter_conversation=None, filter_sender=None, remove_s
 
 def render(data, bin_width, plot_density=False):
     if plot_density:
+        # filter out conversationWithName with only one timestamp (which breaks density plot)
+        for name in data.conversationWithName.unique():
+            if len(data[data.conversationWithName == name].datetime.unique()) == 1:
+                data = data[data.conversationWithName != name]
         plot = ggplot(data, aes(x='datetime', color='conversationWithName')) \
                + geom_density() \
                + scale_x_date(labels='%b %Y') \

--- a/analyse.py
+++ b/analyse.py
@@ -17,11 +17,11 @@ def parse_arguments():
                         help='number of different senders to consider, ordered by number of messages sent')
     parser.add_argument('-b', '--bin-width', dest='bin_width', type=int, default=25, help='bin width for histograms')
     parser.add_argument('--filter-conversation', dest='filter_conversation', type=str, default=None,
-                        help='only keep messages sent in a conversation with this sender')
+                        help='only keep messages sent in a conversation with these senders, separated by comma')
     parser.add_argument('--filter-sender', dest='filter_sender', type=str, default=None,
-                        help='only keep messages sent by this sender')
+                        help='only keep messages sent by these senders, separated by comma')
     parser.add_argument('--remove-sender', dest='remove_sender', type=str, default=None,
-                        help='remove messages sent by this sender')
+                        help='remove messages sent by these senders,separated by comma')
     args = parser.parse_args()
     return args
 
@@ -38,13 +38,16 @@ def load_data(data_paths, filter_conversation=None, filter_sender=None, remove_s
 
     # filtering
     if filter_conversation is not None:
-        df = df[df['conversationWithName'] == filter_conversation]
+        filter_conversation = filter_conversation.split(',')
+        df = df[df['conversationWithName'].isin(filter_conversation)]
 
     if filter_sender is not None:
-        df = df[df['senderName'] == filter_sender]
+        filter_sender = filter_sender.split(',')
+        df = df[df['senderName'].isin(filter_sender)]
 
     if remove_sender is not None:
-        df = df[df['senderName'] != remove_sender]
+        remove_sender = remove_sender.split(',')
+        df = df[~df['senderName'].isin(remove_sender)]
 
     # keep only topN interlocutors
     mf = df.groupby(['conversationWithName'], as_index=False) \

--- a/cloud.py
+++ b/cloud.py
@@ -21,11 +21,11 @@ def parse_arguments():
     parser.add_argument('-m', '--mask-image', dest='mask_image', type=str, default=None,
                         help='image to use as mask', required=True)
     parser.add_argument('--filter-conversation', dest='filter_conversation', type=str, default=None,
-                        help='only keep messages sent in a conversation with this sender')
+                        help='only keep messages sent in a conversation with these senders, separated by comma')
     parser.add_argument('--filter-sender', dest='filter_sender', type=str, default=None,
-                        help='only keep messages sent by this sender')
+                        help='only keep messages sent by these senders, separated by comma')
     parser.add_argument('--remove-sender', dest='remove_sender', type=str, default=None,
-                        help='remove messages sent by this sender')
+                        help='remove messages sent by these senders, separated by comma')
     parser.add_argument('-n', '--num-words', dest='num_words', type=int, default=10000, help='bin width for histograms')
     parser.add_argument('--density', '--dpi', dest='density', type=int, default=100, help='rendered image DPI')
     args = parser.parse_args()
@@ -59,16 +59,19 @@ def main():
     print('Loaded', len(df), 'messages')
 
     if filter_conversation is not None:
+        filter_conversation = filter_conversation.split(',')
         print('Keeping only messages in conversations with', filter_conversation)
-        df = df[df['conversationWithName'] == filter_conversation]
+        df = df[df['conversationWithName'].isin(filter_conversation)]
 
     if filter_sender is not None:
+        filter_sender = filter_sender.split(',')
         print('Keeping only messages sent by', filter_sender)
-        df = df[df['senderName'] == filter_sender]
+        df = df[df['senderName'].isin(filter_sender)]
 
     if remove_sender is not None:
         print('Removing messages sent by', remove_sender)
-        df = df[df['senderName'] != remove_sender]
+        remove_sender = remove_sender.split(',')
+        df = df[~df['senderName'].isin(remove_sender)]
 
     if len(df['text']) == 0:
         print('No messages left! review your filter options')


### PR DESCRIPTION
This PR is to address issue "Improve command line filtering options #9", plus a fix for the density plot to skip a particular conversationWithName, when there is only one timestamp associated with which.