### PR TITLE
parse messenger directory one level more

### DIFF
--- a/parsers/messenger.py
+++ b/parsers/messenger.py
@@ -14,7 +14,7 @@ def main(own_name, file_path, max_exported_messages):
     global MAX_EXPORTED_MESSAGES
     MAX_EXPORTED_MESSAGES = max_exported_messages
     log.info('Parsing Facebook messenger data...')
-    if len(glob.glob(os.path.join(file_path, '**', '*.json'))) == 0:
+    if len(glob.glob(os.path.join(file_path, '**', '**', '*.json'))) == 0:
         log.error(f'No input files found under {file_path}')
         exit(0)
     if own_name is None:


### PR DESCRIPTION
This fixes the problem that messenger.py could not locate .JSON files in Facebook files exported as recently as 11/05/2019. If one copies the contents of the exported 'messages' folder into 'rawdata/messenger', the files therein are one level too deep to be parsed. I think Facebook's export style must have changed.

This commit adds one more layer to the search for files, and the messenger parser now finds the .json files that it was missing before.

Example file structure for reference:
'Chatistics/raw_data/messenger/inbox/usernamehere/message_1.json'

