### PR TITLE
Fix whatsapp parsing

### DIFF
--- a/parsers/whatsapp.py
+++ b/parsers/whatsapp.py
@@ -47,7 +47,6 @@ def infer_datetime_regex(f_path, max_messages=100):
         log.debug(f'Datetime regex inferred: {regex_dt}')
     else:
         regex_dt = regex_datetime
-    print(f"Regex: {regex_left}:-:{regex_dt}:-:{regex_right}")
     return re.compile(f'^{regex_left}{regex_dt}{regex_right}$')
 
 def main(own_name, file_path, max_exported_messages, infer_datetime):
@@ -84,7 +83,6 @@ def parse_messages(files, own_name, infer_datetime):
         text = None
         if infer_datetime:
             regex_message = infer_datetime_regex(f_path)
-            print(regex_message)
         num_lines = sum(1 for _ in open(f_path, 'r'))
         with open(f_path, 'r') as f:
             for line in tqdm(f, total=num_lines):

--- a/parsers/whatsapp.py
+++ b/parsers/whatsapp.py
@@ -34,7 +34,7 @@ def infer_datetime_regex(f_path, max_messages=100):
                         if first:
                             pattern += '('
                             first = False
-                        pattern += '[0-9]'
+                        pattern += '[0-9]*'
                         last = len(pattern)
                     elif l in '.*+[]{}()\\|':
                         pattern += '\\' + l
@@ -47,6 +47,7 @@ def infer_datetime_regex(f_path, max_messages=100):
         log.debug(f'Datetime regex inferred: {regex_dt}')
     else:
         regex_dt = regex_datetime
+    print(f"Regex: {regex_left}:-:{regex_dt}:-:{regex_right}")
     return re.compile(f'^{regex_left}{regex_dt}{regex_right}$')
 
 def main(own_name, file_path, max_exported_messages, infer_datetime):
@@ -83,6 +84,7 @@ def parse_messages(files, own_name, infer_datetime):
         text = None
         if infer_datetime:
             regex_message = infer_datetime_regex(f_path)
+            print(regex_message)
         num_lines = sum(1 for _ in open(f_path, 'r'))
         with open(f_path, 'r') as f:
             for line in tqdm(f, total=num_lines):


### PR DESCRIPTION
`infer_datetime_regex` withing `whatsapp.py` handles single digit month day values in the whatsapp timestamp incorrectly. Causing the parser to ignore a huge amount of messages. This error depends on the first time value encountered.

I'm not quite sure why the regex isn't a constant, but this pull request should fix the problem while maintaining the flexibility of the original function.

Before:
![image](https://user-images.githubusercontent.com/5969147/72621447-8bd6f780-3941-11ea-89e2-7149ca91c4bd.png)
After:
![image](https://user-images.githubusercontent.com/5969147/72621402-78c42780-3941-11ea-93ea-7e6d78f6b772.png)
