### PR TITLE
Clarify where to export messenger data to, and fix export.py to pkl error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Data exported for each message regardless of the platform:
 3. Select the date range you want. **The format *must* be JSON.** Media won't be used, so you can set the quality to "Low" to speed things up.
 4. Click on "Deselect All", then scroll down to select "Messages" only
 5. Click on "Create File" at the top of the list. It will take Facebook a while to generate your archive.
-4. Once the archive is ready, download and extract it, then move the content of the `messages` folder into `./raw_data/messenger/`
+4. Once the archive is ready, download and extract it, then move the `messages` folder into `./raw_data/messenger/`
 
 ### WhatsApp
 

--- a/export.py
+++ b/export.py
@@ -49,7 +49,7 @@ def main():
         elif args.format == 'csv':
             df.to_csv(f_name, index=False, compression=compression)
         elif args.format == 'pkl':
-            with open(f_name, 'wb', encoding="utf8") as f:
+            with open(f_name, 'wb') as f:
                 pickle.dump(df, f)
         else:
             raise Exception(f'Format {args.format} is not supported.')


### PR DESCRIPTION
I mistakenly exported my Facebook messenger data content to the messenger folder, instead of the entire messages folder i had unzipped from the Facebook download file. I saw in an other thread, that others had also done this. The readme could be changed so this would be avoided.

If i run `export.py -format pkl` then i get an error saying:

```
Traceback (most recent call last):
  File "export.py", line 59, in <module>
    main()
  File "export.py", line 52, in main
    with open(f_name, 'wb', encoding="utf8") as f:
ValueError: binary mode doesn't take an encoding argument
```

The error can be avoided by not setting encoding in the open() function. 

